### PR TITLE
Fix preset sharding options and add tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
 
 test {
     useJUnit()
+
+    maxHeapSize = "2g"
 }
 
 jar {


### PR DESCRIPTION
This fixes the three "preset" `--shard` options (`SINGLE`, `CHUNK`, and `SUPERCHUNK`) based on comments in https://github.com/zarr-developers/zarr-java/issues/5.

Using `--shard SINGLE` attempts to create a v3 dataset with a single shard covering the entire array. `--shard CHUNK` creates one shard per chunk, and `--shard SUPERCHUNK` attempts to create shards with 2x2 chunks per shard.

The `--shard` option has no effect on writing v2 data, so should only be used in the context of converting v2 to v3.

As [the `chunkAndShardCompatible` method](https://github.com/glencoesoftware/zarr2zarr/compare/master...melissalinkert:fix-sharding?expand=1#diff-f864572a43cb7efe29c1d5d205de1dbb9cda6debe9477d3b310bc61249aa6cb6R545) suggests, as far as I can tell the chunk, shard, and array shape all need to divide evenly into each other or an exception will be thrown. Those cases should be caught with a warning now, but use caution if testing with v2 input data that has array shapes that are not an exact multiple of the chunk size.

There is a placeholder here for allowing custom shard sizes to be specified; I plan to implement that in a separate PR.