### PR TITLE
More sharding work

### DIFF
--- a/src/main/java/com/glencoesoftware/zarr/Convert.java
+++ b/src/main/java/com/glencoesoftware/zarr/Convert.java
@@ -305,9 +305,17 @@ public class Convert implements Callable<Integer> {
                   // no changes needed
                   break;
                 case SUPERCHUNK:
-                  // each shard covers 2x2 chunks
+                  // each shard covers 2x2 chunks in XY
                   chunkSizes[4] *= 2;
                   chunkSizes[3] *= 2;
+
+                  // shard across other dimensions too, but only
+                  // if the dimension is greater than the chunk size
+                  for (int i=0; i<=2; i++) {
+                    if (shape[i] > chunkSizes[i]) {
+                      chunkSizes[i] *= 2;
+                    }
+                  }
                   break;
                 case CUSTOM:
                   // TODO

--- a/src/main/java/com/glencoesoftware/zarr/Convert.java
+++ b/src/main/java/com/glencoesoftware/zarr/Convert.java
@@ -67,6 +67,7 @@ public class Convert implements Callable<Integer> {
   private boolean writeV2;
 
   private ShardConfiguration shardConfig;
+  private int[] requestedShard; // the requested size for custom sharding
   private String[] codecs;
 
   /**
@@ -136,8 +137,12 @@ public class Convert implements Callable<Integer> {
         shardConfig = Enum.valueOf(ShardConfiguration.class, shard);
       }
       catch (IllegalArgumentException e) {
-        // TODO
         shardConfig = ShardConfiguration.CUSTOM;
+        String[] shardSize = shard.split(",");
+        requestedShard = new int[shardSize.length];
+        for (int i=0; i<shardSize.length; i++) {
+          requestedShard[i] = Integer.parseInt(shardSize[i]);
+        }
       }
     }
   }
@@ -318,7 +323,7 @@ public class Convert implements Callable<Integer> {
                   }
                   break;
                 case CUSTOM:
-                  // TODO
+                  chunkSizes = requestedShard;
                   break;
               }
 

--- a/src/test/java/com/glencoesoftware/zarr/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/zarr/test/ConversionTest.java
@@ -317,7 +317,7 @@ public class ConversionTest {
   }
 
   /**
-   * Test different sharding options
+   * Test different default sharding options
    */
   @Test
   public void testSharding() throws Exception {
@@ -432,12 +432,77 @@ public class ConversionTest {
     }
   }
 
+  /**
+   * Test different custom sharding options
+   */
+  @Test
+  public void testCustomSharding() throws Exception {
+    input = fake("sizeX", "4096", "sizeY", "4096", "sizeT", "2", "sizeC", "3");
+    assertBioFormats2Raw();
+
+    String[] shardOptions = new String[] {
+      "1,1,1,2048,2048",
+      "2,1,1,1024,1024",
+      "1,3,1,4096,4096"
+    };
+    int[][] shardSizes = new int[][] {
+      {1, 1, 1, 2048, 2048},
+      {2, 1, 1, 1024, 1024},
+      {1, 3, 1, 4096, 4096}
+    };
+
+    for (int opt=0; opt<shardOptions.length; opt++) {
+      // first convert v2 produced by bioformats2raw to v3
+      Path v3Output = tmp.newFolder().toPath().resolve("v3-test");
+      Convert v3Converter = new Convert();
+      v3Converter.setInput(output.toString());
+      v3Converter.setOutput(v3Output.toString());
+
+      v3Converter.setSharding(shardOptions[opt]);
+      v3Converter.convertToV3();
+
+      // check list of codecs in the v3 arrays
+
+      Store store = new FilesystemStore(v3Output);
+      Array resolution = Array.open(store.resolve("0", "0"));
+
+      int[] shardSize = shardSizes[opt];
+      Assert.assertArrayEquals(resolution.metadata.chunkShape(), shardSize);
+
+      // now convert v3 back to v2
+      Path roundtripOutput = tmp.newFolder().toPath().resolve("v2-roundtrip-test");
+      Convert v2Converter = new Convert();
+      v2Converter.setInput(v3Output.toString());
+      v2Converter.setOutput(roundtripOutput.toString());
+      v2Converter.setWriteV2(true);
+      v2Converter.convertToV2();
+
+      Path originalOMEXML = output.resolve("OME").resolve("METADATA.ome.xml");
+      Path roundtripOMEXML = roundtripOutput.resolve("OME").resolve("METADATA.ome.xml");
+
+      // make sure the OME-XML is present and not changed
+      Assert.assertEquals(Files.readAllLines(originalOMEXML), Files.readAllLines(roundtripOMEXML));
+
+      // since the image is small, make sure all pixels are identical in both resolutions
+      for (int r=0; r<4; r++) {
+        ZarrArray original = ZarrGroup.open(output.resolve("0")).openArray(String.valueOf(r));
+        ZarrArray roundtrip = ZarrGroup.open(roundtripOutput.resolve("0")).openArray(String.valueOf(r));
+
+        compareZarrArrays(original, roundtrip);
+      }
+    }
+  }
+
   private void compareZarrArrays(ZarrArray original, ZarrArray roundtrip) throws Exception {
     Assert.assertArrayEquals(original.getShape(), roundtrip.getShape());
 
     int[] shape = original.getShape();
-    byte[] originalImage = new byte[shape[2] * shape[3] * shape[4]];
-    byte[] roundtripImage = new byte[shape[2] * shape[3] * shape[4]];
+    int arraySize = 1;
+    for (int s : shape) {
+      arraySize *= s;
+    }
+    byte[] originalImage = new byte[arraySize];
+    byte[] roundtripImage = new byte[arraySize];
     original.read(originalImage, shape);
     roundtrip.read(roundtripImage, shape);
 

--- a/src/test/java/com/glencoesoftware/zarr/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/zarr/test/ConversionTest.java
@@ -375,12 +375,69 @@ public class ConversionTest {
     }
   }
 
+  @Test
+  public void test3DSharding() throws Exception {
+    input = fake("sizeX", "4096", "sizeY", "4096", "sizeZ", "10");
+    // start with a Z chunk size of 2 (== 5 Z chunks)
+    assertBioFormats2Raw("-z", "2");
+
+    String[] shardOptions = new String[] {
+      "SINGLE", "CHUNK", "SUPERCHUNK"
+    };
+    int[][] shardSizes = new int[][] {
+      {1, 1, 10, 4096, 4096},
+      {1, 1, 2, 1024, 1024},
+      {1, 1, 4, 2048, 2048}
+    };
+
+    for (int opt=0; opt<shardOptions.length; opt++) {
+      // first convert v2 produced by bioformats2raw to v3
+      Path v3Output = tmp.newFolder().toPath().resolve("v3-test");
+      Convert v3Converter = new Convert();
+      v3Converter.setInput(output.toString());
+      v3Converter.setOutput(v3Output.toString());
+
+      v3Converter.setSharding(shardOptions[opt]);
+      v3Converter.convertToV3();
+
+      // check list of codecs in the v3 arrays
+
+      Store store = new FilesystemStore(v3Output);
+      Array resolution = Array.open(store.resolve("0", "0"));
+
+      int[] shardSize = shardSizes[opt];
+      Assert.assertArrayEquals(resolution.metadata.chunkShape(), shardSize);
+
+      // now convert v3 back to v2
+      Path roundtripOutput = tmp.newFolder().toPath().resolve("v2-roundtrip-test");
+      Convert v2Converter = new Convert();
+      v2Converter.setInput(v3Output.toString());
+      v2Converter.setOutput(roundtripOutput.toString());
+      v2Converter.setWriteV2(true);
+      v2Converter.convertToV2();
+
+      Path originalOMEXML = output.resolve("OME").resolve("METADATA.ome.xml");
+      Path roundtripOMEXML = roundtripOutput.resolve("OME").resolve("METADATA.ome.xml");
+
+      // make sure the OME-XML is present and not changed
+      Assert.assertEquals(Files.readAllLines(originalOMEXML), Files.readAllLines(roundtripOMEXML));
+
+      // since the image is small, make sure all pixels are identical in both resolutions
+      for (int r=0; r<4; r++) {
+        ZarrArray original = ZarrGroup.open(output.resolve("0")).openArray(String.valueOf(r));
+        ZarrArray roundtrip = ZarrGroup.open(roundtripOutput.resolve("0")).openArray(String.valueOf(r));
+
+        compareZarrArrays(original, roundtrip);
+      }
+    }
+  }
+
   private void compareZarrArrays(ZarrArray original, ZarrArray roundtrip) throws Exception {
     Assert.assertArrayEquals(original.getShape(), roundtrip.getShape());
 
     int[] shape = original.getShape();
-    byte[] originalImage = new byte[shape[3] * shape[4]];
-    byte[] roundtripImage = new byte[shape[3] * shape[4]];
+    byte[] originalImage = new byte[shape[2] * shape[3] * shape[4]];
+    byte[] roundtripImage = new byte[shape[2] * shape[3] * shape[4]];
     original.read(originalImage, shape);
     roundtrip.read(roundtripImage, shape);
 


### PR DESCRIPTION
Follow-up to #1 and https://github.com/zarr-developers/zarr-java/issues/5.

This fixes the check for valid shard/chunk size pairs, adds support for sharding in more than 2 dimensions, and allows custom shard sizes to be specified as a comma-separated array e.g. `--shard 1,1,2,1024,1024`.

